### PR TITLE
Improve error reporting on node creation.

### DIFF
--- a/peekaboo.go
+++ b/peekaboo.go
@@ -259,10 +259,12 @@ func main() {
 				},
 			}
 
-			nodePager := nodes.Create(client, loadBalancerID, opts)
-			nodeList, err := nodePager.ExtractNodes()
-			if err != nil || len(nodeList) != 1 {
-				log.Panicf("Something went terribly wrong on node creation: %v\n", nodeList)
+			nodeList, err := nodes.Create(client, loadBalancerID, opts).ExtractNodes()
+			if err != nil {
+				log.Fatalf("Error enumerating created nodes: %v", err)
+			}
+			if len(nodeList) != 1 {
+				log.Panicf("Something went terribly wrong on node creation: %#v\n", nodeList)
 			}
 			nodePtr = &nodeList[0]
 		}


### PR DESCRIPTION
I'm getting a node creation failure, and I'm not sure why:

```
peekaboo-up[2357]: 2015/06/23 15:31:27 Creating new node
peekaboo-up[2357]: 2015/06/23 15:31:27 Something went terribly wrong on node creation: []
peekaboo-up[2357]: panic: Something went terribly wrong on node creation: []
peekaboo-up[2357]: goroutine 1 [running]:
```

This should help diagnose.

I *suspect* that I have a lot of services trying to register themselves with the same load balancer at once, and I'm hitting that 60-second timeout on certain peekaboo runs. I'll add a flag to increase that to something ridiculous in here, too.