### PR TITLE
Ask forgiveness, not permission

### DIFF
--- a/peekaboo.go
+++ b/peekaboo.go
@@ -28,15 +28,13 @@ import (
 func backoff(interval int, action func() error) error {
 	err := action()
 	for err != nil {
-		err = action()
-
 		if casted, ok := err.(*gophercloud.UnexpectedResponseCodeError); ok {
 			var waitReason string
 			switch casted.Actual {
 			case 422:
-				waitReason = "Load balancer is immutable."
+				waitReason = "Load balancer is immutable"
 			case 413:
-				waitReason = "Rate limit exceeded."
+				waitReason = "Rate limit exceeded"
 			default:
 				// Non-422 error.
 				return err
@@ -53,6 +51,8 @@ func backoff(interval int, action func() error) error {
 			// Non-HTTP error
 			return err
 		}
+
+		err = action()
 	}
 	return nil
 }

--- a/peekaboo.go
+++ b/peekaboo.go
@@ -39,7 +39,7 @@ func backoff(timeout int, action func() error) error {
 				delta := time.Duration(-1000+rand.Intn(2000)) * time.Millisecond
 				d := base + delta
 
-				log.Printf("Load balancer is immutable. Sleeping for %s.", d)
+				log.Printf("Load balancer is immutable. Sleeping for %s", d)
 				time.Sleep(d)
 			} else {
 				// Non-422 error.
@@ -53,8 +53,8 @@ func backoff(timeout int, action func() error) error {
 	return nil
 }
 
-// waitForReady waits for the load balancer with id loadBalancerID to become
-// ACTIVE. It times out after 60 seconds and streamrolls on ahead.
+// waitForReady waits for the load balancer with id loadBalancerID to become ACTIVE. It times out
+// after the timeout (in seconds) elapses and streamrolls on ahead.
 func waitForReady(client *gophercloud.ServiceClient, loadBalancerID int, timeout int) {
 
 	// Ensure the load balancer is ready
@@ -75,7 +75,7 @@ func waitForReady(client *gophercloud.ServiceClient, loadBalancerID int, timeout
 
 }
 
-// findNodeByIPPort gets a load balancer node by IP and Port
+// findNodeByIPPort locates a load balancer node by IP and port.
 func findNodeByIPPort(
 	client *gophercloud.ServiceClient,
 	loadBalancerID int,
@@ -86,12 +86,10 @@ func findNodeByIPPort(
 	// nil until found
 	var found *nodes.Node
 
-	pager := nodes.List(client, loadBalancerID, nil)
-
-	pager.EachPage(func(page pagination.Page) (bool, error) {
+	nodes.List(client, loadBalancerID, nil).EachPage(func(page pagination.Page) (bool, error) {
 		lbNodes, err := nodes.ExtractNodes(page)
 		if err != nil {
-			log.Fatalf("Error during paging load balancer: %v", err)
+			log.Fatalf("Error while paging load balancer nodes: %v", err)
 		}
 
 		for _, trialNode := range lbNodes {
@@ -108,16 +106,15 @@ func findNodeByIPPort(
 	return found
 }
 
-// getIP tries to best guess what IP to work with
+// getIP attempts to determine which IP to work with.
 //
-// Precedence for IP is determined by
-//  - ipPtr being non-nil (peekaboo's -ip flag)
-//  - Service Net Environment variable $RAX_SERVICENET_IPV4
-//  - Public Net Environment variable $RAX_PUBLICNET_IPV4
-//  - Gleaning a 10 dot out of the network interfaces (likely service net)
-//  - eth0
+// The IP address is determined by, in order:
+// * peekaboo's -ip flag
+// * ServiceNet environment variable: $RAX_SERVICENET_IPV4
+// * PublicNet environment variable: $RAX_PUBLICNET_IPV4
+// * Locating a 10 dot address from the network interfaces, likely ServiceNet.
+// * eth0
 func getIP(ipPtr *string) (string, error) {
-
 	serviceNetIPv4 := os.Getenv("RAX_SERVICENET_IPV4")
 	publicNetIPv4 := os.Getenv("RAX_PUBLICNET_IPV4")
 
@@ -131,7 +128,6 @@ func getIP(ipPtr *string) (string, error) {
 	}
 
 	addrs, err := net.InterfaceAddrs()
-
 	if err != nil {
 		return "", err
 	}
@@ -166,8 +162,7 @@ func getIP(ipPtr *string) (string, error) {
 		}
 	}
 
-	return "", errors.New("unable to determine an IP for load balancing")
-
+	return "", errors.New("no IP found")
 }
 
 func main() {
@@ -177,12 +172,6 @@ func main() {
 	disabledPtr := flag.Bool("disable", false, "Disable the node on the load balancer")
 	drainingPtr := flag.Bool("drain", false, "Drain the node from the load balancer")
 	deletePtr := flag.Bool("delete", false, "Delete the node from the load balancer")
-
-	//NOTE: peekaboo allows setting the IP by using
-	//        - environment variables: RAX_SERVICENET_IPV4 or RAX_PUBLICNET_IPV4
-	//        - finding an ip on the system starting with 10. (service net)
-	//        - locating the eth0 interface
-	//        - providing an ip as a flag is fine too and will take precedence
 	ipPtr := flag.String("ip", "", "IP address to register/deregister on the load balancer")
 	timeout := flag.Int("timeout", 60, "Seconds to wait for the load balancer to become available")
 
@@ -200,54 +189,45 @@ func main() {
 	strLoadBalancerID := os.Getenv("LOAD_BALANCER_ID")
 	strAppPort := os.Getenv("APP_PORT")
 
-	/**
-	 * Retrieve port for load balancer's node, defaulting to 80
-	 */
+	// Retrieve the port for this load balancer node, defaulting to 80.
 	var nodePort = 80
-
 	if strAppPort == "" {
 		log.Printf("$APP_PORT not set, defaulting to 80")
 	} else {
 		nodePort, err = strconv.Atoi(strAppPort)
 		if err != nil {
-			log.Fatalf("Unable to parse integer from $APP_PORT: %v\n", strAppPort)
+			log.Fatalf("Unable to parse integer from $APP_PORT: %v", strAppPort)
 		}
 	}
 
-	/**
-	 * Determine the IP Address for the load balancer's node
-	 */
+	// Determine the IP Address for the load balancer's node
 	nodeAddress, err := getIP(ipPtr)
 	if err != nil {
-		log.Fatalln(err)
+		log.Fatalf("Unable to determine IP address: %v", err)
 	}
 
-	/**
-	 * Retrive Load Balancer ID
-	 */
+	// Retrieve the Load Balancer ID.
 	if strLoadBalancerID == "" {
 		log.Fatalln("$LOAD_BALANCER_ID must be set")
 	}
 	loadBalancerID, err := strconv.Atoi(strLoadBalancerID)
 	if err != nil {
-		log.Fatalf("$LOAD_BALANCER_ID not an integer: %v\n", loadBalancerID)
+		log.Fatalf("$LOAD_BALANCER_ID [%s] is not an integer: %v", strLoadBalancerID, err)
 	}
 
 	provider, err := rackspace.AuthenticatedClient(gophercloud.AuthOptions{
 		Username: username,
 		APIKey:   APIKey,
 	})
-
 	if err != nil {
-		log.Fatalf("Trouble authenticating to Rackspace: %v\n", err)
+		log.Fatalf("Trouble authenticating to Rackspace: %v", err)
 	}
 
 	client, err := rackspace.NewLBV1(provider, gophercloud.EndpointOpts{
 		Region: region,
 	})
-
 	if err != nil {
-		log.Fatalf("Creating load balancer client in %v failed: %v\n", region, err)
+		log.Fatalf("Creating load balancer client in %v failed: %v", region, err)
 	}
 
 	nodePtr := findNodeByIPPort(client, loadBalancerID, nodeAddress, nodePort)
@@ -260,15 +240,11 @@ func main() {
 		if *disabledPtr {
 			condition = nodes.DISABLED
 		} else if *drainingPtr {
-			//TODO: Watch the interface on the right process/container to determine
-			//      when connections have dropped, and set to DISABLED
 			condition = nodes.DRAINING
 		}
 
-		log.Printf("Setting %v:%v to be %v on load balancer %v\n",
-			nodeAddress, nodePort,
-			condition,
-			loadBalancerID)
+		log.Printf("Setting %v:%v to be %v on load balancer %v",
+			nodeAddress, nodePort, condition, loadBalancerID)
 
 		if nodePtr != nil {
 			log.Printf("Updating existing node %v", *nodePtr)
@@ -285,7 +261,7 @@ func main() {
 			}
 
 		} else {
-			log.Printf("Creating new node")
+			log.Printf("Creating new node.")
 			opts := nodes.CreateOpts{
 				nodes.CreateOpt{
 					Address:   nodeAddress,
@@ -299,12 +275,11 @@ func main() {
 				created, err = nodes.Create(client, loadBalancerID, opts).ExtractNodes()
 				return err
 			})
-
 			if err != nil {
-				log.Fatalf("Error enumerating created nodes: %v", err)
+				log.Fatalf("Error creating the node: %v", err)
 			}
 			if len(created) != 1 {
-				log.Fatalf("Something went terribly wrong on node creation: %#v\n", created)
+				log.Fatalf("Something went terribly wrong during node creation: %#v", created)
 			}
 			nodePtr = &created[0]
 		}
@@ -317,7 +292,7 @@ func main() {
 			log.Fatalf("Update to retrieve final node state: %v", err)
 		}
 
-		log.Printf("Final node state: %v\n", *nodePtr)
+		log.Printf("Final node state: %v", *nodePtr)
 	} else {
 		// Delete an existing node from the balancer. Do nothing if no node exists.
 		if nodePtr != nil {

--- a/peekaboo.go
+++ b/peekaboo.go
@@ -48,8 +48,7 @@ func backoff(interval int, action func() error) error {
 			log.Printf("%s. Sleeping for %s", waitReason, d)
 			time.Sleep(d)
 		} else {
-			// Non-HTTP error
-			return err
+			log.Printf("Non-HTTP error: %v", err)
 		}
 
 		err = action()
@@ -204,6 +203,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("Trouble authenticating to Rackspace: %v", err)
 	}
+	provider.HTTPClient.Timeout = 30 * time.Second
 
 	client, err := rackspace.NewLBV1(provider, gophercloud.EndpointOpts{
 		Region: region,


### PR DESCRIPTION
There's a race condition in a few places here, where peekaboo uses `waitForReady` to sleep until the load balancer is mutable and then attempts to mutate it. If two instances of peekaboo both notice that the balancer is available at once, one of them will fail messily when the actual mutation call is performed.

Instead, this uses a `backoff` function that attempts to perform the mutation, detects the 422 response, and waits for a timeout period perturbed by a random delta.
